### PR TITLE
fix phpunit10 deprecations

### DIFF
--- a/test/WebTest.php
+++ b/test/WebTest.php
@@ -194,7 +194,7 @@ class WebTest extends TestUtil
         $this->assertEquals('#3f80bfd9', $res->getRgbaHexColor());
     }
 
-    public function getBadColor()
+    public static function getBadColor()
     {
         return array(
             array('g(-)'),


### PR DESCRIPTION
# Description

```
1 test triggered 1 PHPUnit deprecation:

1) Test\WebTest::testGetColorObjBad
Data Provider method Test\WebTest::getBadColor() is not static

/dev/shm/BUILD/tc-lib-color-44dd214d6ccd6970b87ab54615b59015707fb888/test/WebTest.php:209

```
...


## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [ ] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue) → The patch number in the VERSION file has been increased.
- [ ] New feature (non-breaking change which adds functionality) → The minor number in the VERSION file has been increased.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) → The major number in the VERSION file has been increased.
- [ ] Automation.
- [ ] Documentation.
- [ ] Example.
- [x] Testing.
